### PR TITLE
Fix upload file unicode

### DIFF
--- a/app/controllers/projects/attachments_controller.rb
+++ b/app/controllers/projects/attachments_controller.rb
@@ -1,6 +1,6 @@
 class Projects::AttachmentsController < Projects::ApplicationController
 
-  before_action :set_attachment, only: [ :show, :destroy ]
+  before_action :set_attachment, only: [ :show, :destroy, :download ]
 
   def index
     @q = @project.attachments.search(params[:q])
@@ -29,6 +29,11 @@ class Projects::AttachmentsController < Projects::ApplicationController
     authorize @attachment
     @attachment.destroy
     respond_with @attachment, location: project_attachments_path
+  end
+
+  def download
+    authorize @attachment
+    send_data(@attachment.path.url, :filename => @attachment.download_filename)
   end
 
   protected

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -14,6 +14,10 @@ class Attachment < ActiveRecord::Base
     became
   end
 
+  def download_filename
+    original_filename || "#{name}.#{path.file.extension}"
+  end
+
   def self.intelligent_construct(params, project, user)
     attachment = Attachment::Other.new(params.merge(project: project, user: user))
 
@@ -32,6 +36,8 @@ class Attachment < ActiveRecord::Base
     if attachment.name.blank?
       attachment.name = attachment.path.file.filename
     end
+
+    attachment.original_filename = attachment.path.file.filename
 
     attachment
   end

--- a/app/models/attachment/image.rb
+++ b/app/models/attachment/image.rb
@@ -1,6 +1,6 @@
 class Attachment::Image < Attachment
 
-  validates :path, presence: true
+  validates :path, :original_filename, presence: true
 
   def self.policy_class
     AttachmentPolicy

--- a/app/models/attachment/other.rb
+++ b/app/models/attachment/other.rb
@@ -1,6 +1,6 @@
 class Attachment::Other < Attachment
 
-  validates :path, presence: true
+  validates :path, :original_filename, presence: true
 
   def self.policy_class
     AttachmentPolicy

--- a/app/policies/attachment_policy.rb
+++ b/app/policies/attachment_policy.rb
@@ -12,4 +12,8 @@ class AttachmentPolicy < ApplicationPolicy
     record.project.has_member?(user)
   end
 
+  def download?
+    record.project.has_member?(user)
+  end
+
 end

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -6,6 +6,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
   include CarrierWave::MimetypeableConcern
 
+  CarrierWave::SanitizedFile.sanitize_regexp = /[^[:word:]\.\-\+]/
   # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog
@@ -21,6 +22,17 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def filename
+    "#{secure_token}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+
+  def secure_token
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/app/views/projects/attachments/_other.html.slim
+++ b/app/views/projects/attachments/_other.html.slim
@@ -10,7 +10,7 @@
   i.massive.file.icon
   h3.ui.center.aligned.header = attachment.name
   h4.ui.center.aligned.header = '1111 MB Binary'
-  = link_to attachment.path.url do
+  = link_to download_project_attachment_path(@project, attachment) do
     .ui.circular.icon.button
       i.cloud.download.icon
     = 'Download File'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,9 @@ Rails.application.routes.draw do
       resources :issues  , concerns: [:commentable, :closeable]
       resources :sprints , concerns: [:commentable, :closeable]
       resources :comments ,only: [:update, :destroy]
-      resources :attachments
+      resources :attachments do
+        get 'download', on: :member
+      end
       resources :posts, as: 'attachment_posts'
       resources :snippets, as: 'attachment_snippets'
       resources :labels, constraints: {id: /\d+/}

--- a/db/migrate/20150125081515_add_original_filename_to_attachments.rb
+++ b/db/migrate/20150125081515_add_original_filename_to_attachments.rb
@@ -1,0 +1,5 @@
+class AddOriginalFilenameToAttachments < ActiveRecord::Migration
+  def change
+    add_column :attachments, :original_filename, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150120151617) do
+ActiveRecord::Schema.define(version: 20150125081515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_trgm"
   enable_extension "fuzzystrmatch"
+  enable_extension "pg_trgm"
 
   create_table "attachments", force: :cascade do |t|
     t.string   "name"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20150120151617) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "original_filename"
   end
 
   create_table "comments", force: :cascade do |t|


### PR DESCRIPTION
Fix unicode file name missing issue.
Using uuid as a unique filename to store the uploaded file.
Apply original filename when user wanna download a attachment.